### PR TITLE
require-snippet changed to use camelCase for vars

### DIFF
--- a/Snippets/require.tmSnippet
+++ b/Snippets/require.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>var ${2/^.*?([\w_]+).*$/\L$1/} = require(${2:'${1:sys}'});</string>
+	<string>var ${2:${1/(?:_|-)([A-Za-z0-9]+)(?:\.js)?/(?2::\u$1)/g}} = require('${1:sys}')$0;</string>
 	<key>name</key>
 	<string>require</string>
 	<key>scope</key>


### PR DESCRIPTION
Good day, Dr. Nic!

I've tweaked the require snippet to make camelCase vars, like so:

```
var busterPromise = require('buster-promise');
```

while the old one would suggest an invalid var:

```
var buster-promise = require('buster-promise');
```

Hopefully you think it's a change for the better. :-)
